### PR TITLE
Merge

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Base ----------------------------------------
+pyside6>=6.0.0
 matplotlib>=3.3.0
 numpy>=1.22.2  # pinned by Snyk to avoid a vulnerability
 opencv-python>=4.6.0
@@ -22,7 +23,7 @@ seaborn>=0.11.0
 
 # Export --------------------------------------
 # coremltools>=7.0  # CoreML export
-onnx>=1.12.0  # ONNX export
+# onnx>=1.12.0  # ONNX export
 # onnxsim>=0.4.1  # ONNX simplifier
 # nvidia-pyindex  # TensorRT export
 # nvidia-tensorrt  # TensorRT export
@@ -44,7 +45,7 @@ thop>=0.1.1  # FLOPs computation
 # Human Tracker Dependencies --------------------
 opencv-python
 cvzone
-ultralytics
+ultralytics>=8.0.0
 
 # CUDA and Audio --------------------------------
 cuda-python>=12.3.0  # CUDA Python

--- a/yolo-Weights/yolo11n.pt
+++ b/yolo-Weights/yolo11n.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ebbc80d4a7680d14987a577cd21342b65ecfd94632bd9a8da63ae6417644ee1
+size 5613764

--- a/yolo-Weights/yolov10n-face.pt
+++ b/yolo-Weights/yolov10n-face.pt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58bc4397f6e5a1cd69411cf46615e60b9bd89a00c1dfd92307f873f626528c18
+size 5736435


### PR DESCRIPTION
This pull request includes the addition of two new YOLO weight files to the `yolo-Weights` directory. These files are likely used for different YOLO models.

* [`yolo-Weights/yolo11n.pt`](diffhunk://#diff-45984d00d565f8a9f2e2d3fa2b82e3a6cd87868639cb745995447f1a5c28444eR1-R3): Added new weight file with a size of 5613764 bytes.
* [`yolo-Weights/yolov10n-face.pt`](diffhunk://#diff-4daac79b6d7d1dbdc4714a5fdeb11e06710c3bf2962410e9ee445080eb8cd3baR1-R3): Added new weight file with a size of 5736435 bytes.